### PR TITLE
Improve deletion progress UX

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -69,6 +69,7 @@ const App: React.FC = () => {
   const deleteSelectedPaths = async () => {
     try {
       setIsDeleting(true);
+      setDeletionProgress(0);
       console.log('準備刪除路徑:', selectedPaths);
       await invoke('delete_paths_with_progress', { paths: selectedPaths });
       setSnackbarMessage('所有選擇的路徑已成功刪除');
@@ -98,7 +99,7 @@ const App: React.FC = () => {
     // 監聽來自後端的 "delete-progress" 事件
     const unlisten = listen<number>('delete-progress', (event) => {
       console.log(event.payload);
-      setDeletionProgress(event.payload*100);
+      setDeletionProgress(event.payload);
       // setProgress(event.payload); // 更新進度條的百分比
     });
 
@@ -128,7 +129,16 @@ const App: React.FC = () => {
           <Button variant="contained" color="secondary" onClick={confirmAndDelete} disabled={isDeleting}>
             刪除選擇的檔案或資料夾
           </Button>
-          {isDeleting && <LinearProgress variant="determinate" value={deletionProgress} />}
+          {isDeleting && (
+            <div style={{ display: 'flex', alignItems: 'center', marginTop: '10px' }}>
+              <LinearProgress
+                variant="determinate"
+                value={deletionProgress}
+                style={{ flexGrow: 1, marginRight: '10px' }}
+              />
+              <span>{Math.round(deletionProgress)}%</span>
+            </div>
+          )}
         </div>
       )}
       <Snackbar


### PR DESCRIPTION
## Summary
- reset deletion progress at the start of deletion
- show real progress from backend without scaling
- display progress percent next to a progress bar with spacing

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68552bec21148331b4982a09a6eb4f0d